### PR TITLE
Added G2A exploit scam link

### DIFF
--- a/links.txt
+++ b/links.txt
@@ -2269,3 +2269,4 @@ https://viagraonlineiptx.com/
 http://nestria.pl/icn
 https://mxcd.online/
 http://rl.rf.gd
+https://www.mediafire.com/file/kluezu8ixvawqx8/G2A_Refund_Exploit.pdf/file


### PR DESCRIPTION
Bot users were using this mediafire link (line 2272 - mediafire.com/file/kluezu8ixvawqx8/G2A_Refund_Exploit.pdf/file) to spread it